### PR TITLE
Content Script messaging

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,9 +8,6 @@
     "default_popup": "popup.html",
     "default_icon": "icon.png"
   },
-  "chrome_url_overrides": {
-    "newtab": "newtab.html"
-  },
   "icons": {
     "128": "icon.png"
   },

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -2,20 +2,35 @@ import { printLine } from './modules/print';
 
 console.log('Content script works!');
 console.log('Must reload extension for modifications to take effect.');
-
+document.querySelector('div').addEventListener('selectionchange', () => {
+  console.log('Selection updated');
+});
 function getRandomColor() {
-    var letters = '0123456789ABCDEF';
-    var color = '#';
-    for (var i = 0; i < 6; i++) {
-      color += letters[Math.floor(Math.random() * 16)];
-    }
-    return color;
+  var letters = '0123456789ABCDEF';
+  var color = '#';
+  for (var i = 0; i < 6; i++) {
+    color += letters[Math.floor(Math.random() * 16)];
   }
+  return color;
+}
 
+chrome.runtime.onMessage.addListener((req, send, sendResponse) => {
+  console.log(
+    send.tab ? 'from a content script:' + send.tab.url : 'from the extension'
+  );
+  let paragraphs = document.getElementsByTagName('p');
+  console.log(paragraphs);
+  for (const paragraph of paragraphs) {
+    //console.log(paragraph.textContent)
+    paragraph.style['background-color'] = getRandomColor();
+  }
+  sendResponse({ message: 'ACK' });
+});
 printLine("Using the 'printLine' function from the Print Module");
-let paragraphs = document.getElementsByTagName('p');
-console.log(paragraphs)
+/*let paragraphs = document.getElementsByTagName('p');
+//console.log(paragraphs)
 for (const paragraph of paragraphs) {
-    console.log(paragraph)
+    //console.log(paragraph.textContent)
     paragraph.style['background-color'] = getRandomColor();
 }
+*/

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -9,7 +9,13 @@ import Card from 'react-bootstrap/Card';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
+import message from './modules/messenger'
 import './Popup.css';
+
+const getAuthor = () => {
+  /* We must send a message to the content script and wait for response from it */
+}
+
 
 const Popup = () => {
   return (
@@ -36,7 +42,7 @@ const Popup = () => {
                     <Button variant="outline-primary" block>Comment</Button>
                   </Col>
                   <Col className="pr-0" style={{paddingLeft: "5px"}}>
-                    <Button block >More</Button>
+                    <Button block onClick = {message}>More</Button>
                   </Col>
                 </Row>
               </Col>

--- a/src/pages/Popup/modules/messenger.js
+++ b/src/pages/Popup/modules/messenger.js
@@ -1,0 +1,8 @@
+const messageContent = () => {
+    chrome.tabs.query({active: true, currentWindow: true}, (tabs)=>{
+        chrome.tabs.sendMessage(tabs[0].id, {message: "Component is sending message to content script"})
+    })
+  }
+
+
+  export default messageContent;


### PR DESCRIPTION
- Updated manifest to get rid of annoying new tab override
- Added a messenger module that will be expanded upon later that will allow us to communicate between the content script and extension
- When the more button is pressed on the extension, the text changes color on the current webpage [For demo?]


Web page before more button is pressed:
![image](https://user-images.githubusercontent.com/29382267/106980967-2792fb80-672f-11eb-840c-68a646ddb33e.png)



Web page after more button is pressed: 
![image](https://user-images.githubusercontent.com/29382267/106981032-40031600-672f-11eb-853f-1192785e379e.png)


Web page now receives signal from extension's pop-up:
![image](https://user-images.githubusercontent.com/29382267/106981126-70e34b00-672f-11eb-8240-b1fd02a6ac0e.png)
