### PR TITLE
Reliant now works on any website and auto-loads on 

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,10 +27,9 @@
     "content.styles.css",
     "icon-128.png",
     "icon-34.png",
-    "icon.png",
-    "popup.html"
+    "icon.png"
   ],
-  "version": "0.1",
+  "version": "1.1",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -43,7 +43,3 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     }
     return true; //This line is what allows us to wait for the async sendResponse
 });
-
-
-
-

--- a/src/pages/Content/content.styles.css
+++ b/src/pages/Content/content.styles.css
@@ -7,18 +7,20 @@ input[type='radio'] {
   transition: color 200ms;
 }
 
-.questionnaire {
+.bordered-container {
   background: rgba(255, 255, 255, 0);
   border-style: solid;
   border-width: 15px;
   border-color: darksalmon;
   border-radius: 25px;
-  max-width: 800px;
   height: auto;
   margin: auto;
   margin-top: 20px;
   margin-bottom: 20px;
   padding: 15px;
+}
+.questionnaire-container {
+  max-width: 800px;
 }
 
 .question-container {
@@ -78,4 +80,43 @@ input[type='radio'] {
 .submit-btn.disabled,
 .submit-btn:disabled {
   opacity: 0.65;
+}
+
+.comment-container {
+  background-color: aliceblue;
+  width: 300px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+}
+.comment-input-container {
+  background-color: blue;
+  height: 2rem;
+  position: relative;
+}
+.comment-btn {
+  background-color: red;
+  border-radius: 3px;
+  position: absolute;
+  margin: 0;
+  border: none;
+  vertical-align: middle;
+  height: 100%;
+  width: 2rem;
+  right: 0;
+  bottom: 0;
+}
+
+.comment-input {
+  vertical-align: middle;
+  position: absolute;
+  padding-left: 1rem;
+  padding-right: 3rem;
+  margin: 0;
+  border: none;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  white-space: pre;
+  word-break: break-word;
 }

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -120,7 +120,7 @@ async function activateReliant() {
     return; // Prevents Reliant from being activated if the site is not done loading.
   }
   ACTIVATED = true;
-  console.log('activated reliant');
+  console.log('activated reliant', getActivateState());
   const url = await getURL();
   const userInfo = await getUserInfo();
   const hostname = new URL(url).hostname;

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -1,15 +1,26 @@
 import React from 'react';
 import { render } from 'react-dom';
 import Questionnaire from './modules/Questionnaire';
+import Comment from './modules/Comment';
 import { URLS } from '../Background/workingUrls';
 import axios from 'axios';
 import { calculateScore } from '../../containers/Score/Score';
 
 console.log('Content script works!');
 console.log('Must reload extension for modifications to take effect.');
+
+const comment = document.createElement('div')
+const questionnaire = document.createElement('div')
+var ACTIVATED = false;
+var LOADED = false;
+var paragraphs = null;
+
 document.querySelector('div').addEventListener('selectionchange', () => {
   console.log('Selection updated');
 });
+
+export function getLoadedState() {return LOADED}
+export function getActivateState() {return ACTIVATED}
 
 export async function getURL() {
   return new Promise((resolve) => {
@@ -52,10 +63,17 @@ async function createQuestionnaire(userId, url, hostname) {
     genre = "Political"
   }
   if (contentBody == undefined) {
-    contentBody = document.body;
+    const articles = document.getElementsByTagName('article');
+    if (articles.length > 0) {
+      contentBody = articles[articles.length -1]
+    } else {
+      contentBody = document.querySelector('body');
+    }
   }
-  const questionnaire = document.createElement('div');
   contentBody.appendChild(questionnaire);
+  contentBody.appendChild(comment);
+  console.log("Content Body" , contentBody)
+  render(<Comment />, comment)
   render(<Questionnaire userId={userId} url={url} genre={genre} />, questionnaire);
 }
 
@@ -67,6 +85,8 @@ export async function getUserInfo() {
   });
 }
 
+
+
 function getRandomColor() {
   var letters = '0123456789ABCDEF';
   var color = '#';
@@ -77,37 +97,46 @@ function getRandomColor() {
 }
 
 var first = true; //Used to ensure the questionnaire can only be injected once.
-var loaded = false;
 var colors = []; // Array holding paragraph colors in the form [original, random]
 var even = 0; // 0 --> Original Color, 1 --> Random Color
-window.onload = function () {
-  loaded = true;
+window.onload = async function () {
+  LOADED = true;
   console.log('LOADED');
+  const hostname = new URL(await getURL()).hostname;
+  console.log(hostname)
+  for (const key in URLS) {
+    if (hostname.includes(URLS[key])) {
+      activateReliant();
+      break;
+    }
+  }
 };
 var timeOpened = new Date().getTime();
 
+
 async function activateReliant() {
-  if (!loaded) {
+  if (!LOADED) {
     console.log('page not loaded');
     return; // Prevents Reliant from being activated if the site is not done loading.
   }
+  ACTIVATED = true;
   console.log('activated reliant');
   const url = await getURL();
   const userInfo = await getUserInfo();
   const hostname = new URL(url).hostname;
 
   //Check if hostname is in URLS
-  var foundURL = false;
-  for (const key in URLS) {
-    if (hostname.includes(URLS[key])) {
-      foundURL = true;
-      break;
-    }
-  }
-  if (!foundURL) {
-    console.log('UNSUPPORTED WEBSITE');
-    return;
-  }
+  // var foundURL = false;
+  // for (const key in URLS) {
+  //   if (hostname.includes(URLS[key])) {
+  //     foundURL = true;
+  //     break;
+  //   }
+  // }
+  // if (!foundURL) {
+  //   console.log('UNSUPPORTED WEBSITE');
+  //   return;
+  // }
 
   axios.post('http://localhost:4000/api/user/updateSites',{
     _id: userInfo.id,
@@ -132,27 +161,32 @@ async function activateReliant() {
     .catch(() => {
       console.log('Internal server error');
     });
-
-
-  if (first) {
     createQuestionnaire(userInfo.id, url, hostname);
-  }
 
   //Highlight everything
-  even = (even + 1) % 2;
-  let paragraphs = document.getElementsByTagName('p');
-  var i = 0;
+  paragraphs = document.getElementsByTagName('p');
+  var i = 0
   for (const paragraph of paragraphs) {
     //console.log(paragraph.textContent)
     if (first) {
       colors.push([paragraph.style['background-color'], getRandomColor()]);
-      paragraph.style['background-color'] = colors[i][1];
-    } else {
-      paragraph.style['background-color'] = colors[i][even];
     }
+    paragraph.style['background-color'] = colors[i][1];
     i++;
   }
   first = false;
+}
+
+function deactivateReliant() {
+  ACTIVATED = false;
+  console.log("Deactivating Reliant")
+  comment.remove();
+  questionnaire.remove();
+  var i = 0
+  for (const paragraph of paragraphs) {
+    paragraph.style['background-color'] = colors[i][0];
+    i++;
+  }
 }
 
 export async function submitQuestionnaire(score) {
@@ -217,9 +251,9 @@ export async function submitQuestionnaire(score) {
 
 //Runs when activate is pressed from Popup
 chrome.runtime.onMessage.addListener((req, send, sendResponse) => {
-  if (req.type === 'injectReact') {
-    //Do nt
-  } else if (req.type === 'activate') {
+  if (req.type === 'activate') {
     activateReliant();
+  } else if (req.type === 'deactivate') {
+    deactivateReliant();
   }
 });

--- a/src/pages/Content/modules/Comment.js
+++ b/src/pages/Content/modules/Comment.js
@@ -1,0 +1,26 @@
+import React, {useEffect, useState} from 'react';
+import {FaRegThumbsUp} from 'react-icons/fa';
+
+function Comment() {
+    return (
+    <div className="bordered-container comment-container">
+      <div className="voting-container">
+       
+      </div>
+      <h1>This is the comment title</h1>
+      <p>
+        Lorem, ipsum dolor sit amet consectetur adipisicing elit. Eius
+        aspernatur ad ab veritatis explicabo sit repellat earum porro deserunt?
+        Modi ipsum repellendus consequatur nisi dolorem natus, qui fugit iste
+        possimus.
+      </p>
+      <div className="comment-input-container">
+        <input className="comment-input" type="text" placeholder="Comment" />
+        <input className="comment-btn" type="button"/>
+        {/* <FaRegThumbsUp></FaRegThumbsUp> */}
+      </div>
+    </div>
+    );
+};
+
+export default Comment;

--- a/src/pages/Content/modules/Questionnaire.js
+++ b/src/pages/Content/modules/Questionnaire.js
@@ -66,7 +66,7 @@ function Questionnaire(props) {
   
 
   return (
-    <div className="questionnaire">
+    <div className="bordered-container questionnaire-container">
       <h1>Questionnaire</h1>
       <div className="question-container">
         {questions.map((question, i) => {0

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import authorImage from '../../assets/img/escobar.jpg';
 import Image from 'react-bootstrap/Image';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
 import message from './modules/messenger';
-import { getUserInfo, getURL, getActivateState, getLoadedState } from '../Content/index';
 import axios from 'axios';
 import './Popup.css';
 import StarRating from './modules/StarRating';
@@ -17,10 +15,10 @@ const Popup = () => {
   const [activated, setActivated] = useState(false);
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
-    console.log("Activated", getActivateState())
-    setActivated(getActivateState());
-    getUserInfo().then((data) => setUserEmail(data.email));
-    getURL().then((url) => {
+    chrome.runtime.sendMessage('userInfo', (userInfo) => {
+      setUserEmail(userInfo.email)
+    });
+    chrome.runtime.sendMessage('activeURL', (url) => {
       console.log(url);
       axios
         .get('http://localhost:4000/api/websites/getSiteData', {
@@ -47,7 +45,7 @@ const Popup = () => {
         <Col xs="auto" className="pl-0 pr-0">
           <Image
             style={{ width: '150px', height: '150px' }}
-            src={authorImage}
+            src={"https://i0.wp.com/celikkol.net/wp-content/uploads/2016/03/Author-Icon.png?zoom=2&fit=1024%2C1024&ssl=1"}
             rounded
           />
         </Col>
@@ -56,7 +54,7 @@ const Popup = () => {
           className="pr-0"
           style={{ paddingLeft: '10px', textAlign: 'left' }}
         >
-          <h4 className="mb-0 mt-0">Pablo Escobar</h4>
+          <h4 className="mb-0 mt-0">Author Name</h4>
           <span>Senior Journalist</span>
           <div className="reliability-container">
             <h6>Reliability Score:</h6>

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -6,9 +6,7 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
 import message from './modules/messenger';
-import InputGroup from 'react-bootstrap/InputGroup';
-import { getUserInfo, getURL } from '../Content/index';
-import starRating from './modules/StarRating';
+import { getUserInfo, getURL, getActivateState, getLoadedState } from '../Content/index';
 import axios from 'axios';
 import './Popup.css';
 import StarRating from './modules/StarRating';
@@ -16,7 +14,11 @@ import StarRating from './modules/StarRating';
 const Popup = () => {
   const [userEmail, setUserEmail] = useState(null);
   const [reliabilityScore, setReliabilityScore] = useState(null);
+  const [activated, setActivated] = useState(false);
+  const [loaded, setLoaded] = useState(false);
   useEffect(() => {
+    console.log("Activated", getActivateState())
+    setActivated(getActivateState());
     getUserInfo().then((data) => setUserEmail(data.email));
     getURL().then((url) => {
       console.log(url);
@@ -74,8 +76,16 @@ const Popup = () => {
               </Button>
             </Col>
             <Col className="pr-0" style={{ paddingLeft: '5px' }}>
-              <Button block onClick={message}>
-                Activate
+              <Button block 
+              onClick={() => {
+                if (activated) {
+                  message("deactivate")
+                  setActivated(false)
+                } else {
+                  message("activate")
+                  setActivated(true)
+                }}}>
+                {activated ? "Deactivate" : "Activate"} 
               </Button>
             </Col>
           </Row>

--- a/src/pages/Popup/modules/messenger.js
+++ b/src/pages/Popup/modules/messenger.js
@@ -1,6 +1,6 @@
-const messageContent = () => {
+const messageContent = (type) => {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs)=>{
-        chrome.tabs.sendMessage(tabs[0].id, {type: "activate"})
+        chrome.tabs.sendMessage(tabs[0].id, {type: type})
     })
   }
 


### PR DESCRIPTION
- The extension now runs automatically on any of our list of websites and allows the user to activate it on any site they want by putting the questionnaire to default positions (at the end of an article if it exists or the end of the body)

- The bug where the content script was running in the popup is fixed by using messages rather than imports in the popup.

- A basic comment UI is also implemented but is currently places through absolute positions at 50% screen height

Still todo
- [ ] popup doesn't recognize that the extension is active if it is autoloaded (we need to check active state)
- [ ] popup should disable activate button until the page is fully loaded
- [ ] comment UI and location is not done