### PR TITLE
Hightlight hotfix

### DIFF
--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -308,6 +308,9 @@ async function activateReliant() {
       if (comp == false || (selection == lastSelection && isToolTipVisible)) {
         console.log('I dont want to render at all');
         e.stopPropagation();
+        if (isToolTipVisible) {
+          closeToolTip();
+        }
         return false;
       } else if (selection.length > 0) {
         //Render the tooltip


### PR DESCRIPTION
When selection is discarded by clicking on the actual selection the tooltip disappears