### PR TITLE
Tooltip positioning fix

### DIFF
--- a/src/pages/Content/content.styles.css
+++ b/src/pages/Content/content.styles.css
@@ -68,13 +68,13 @@ input[type='radio'] {
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
     border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   color: #fff;
-  background-color: #28a745;
+  background-color: #28a745!important;
   border-color: #28a745;
 }
 
 .submit-btn:hover {
   color: #fff;
-  background-color: #218838;
+  background-color: #218838!important;
   border-color: #1e7e34;
 }
 
@@ -1160,8 +1160,9 @@ aside.paywall-bar.paywall-bar--visible {
   display: none;
 }
 
-.reliant-tooltip {
+#reliant-tooltip {
   position: absolute;
   padding-bottom: 10px;
-  transform: translate(-50%, -100%);
+  -webkit-transform: translate(-50%,-100%)!important;
+  transform: translate(-50%, -100%)!important;
 }

--- a/src/pages/Content/content.styles.css
+++ b/src/pages/Content/content.styles.css
@@ -1168,6 +1168,7 @@ aside.paywall-bar.paywall-bar--visible {
 }
 
 #button-fix {
+  border: 0;
   padding: 0.25rem 0.5rem;
 
 }

--- a/src/pages/Content/content.styles.css
+++ b/src/pages/Content/content.styles.css
@@ -1166,3 +1166,9 @@ aside.paywall-bar.paywall-bar--visible {
   -webkit-transform: translate(-50%,-100%)!important;
   transform: translate(-50%, -100%)!important;
 }
+
+#button-fix {
+  border: 0;
+  padding: 0.25rem 0.5rem;
+
+}

--- a/src/pages/Content/content.styles.css
+++ b/src/pages/Content/content.styles.css
@@ -1168,7 +1168,6 @@ aside.paywall-bar.paywall-bar--visible {
 }
 
 #button-fix {
-  border: 0;
   padding: 0.25rem 0.5rem;
 
 }

--- a/src/pages/Content/modules/Tooltip-Component.js
+++ b/src/pages/Content/modules/Tooltip-Component.js
@@ -8,12 +8,13 @@ import {FaStickyNote} from 'react-icons/fa';
 
 
 let tooltip = document.createElement('div');
-tooltip.className = "reliant-tooltip btn-group btn-group-sm";
+tooltip.id = "reliant-tooltip"
+tooltip.className = "btn-group btn-group-sm";
 
 export function createTooltip(x, y) {
     tooltip.style.top = y + 'px';
     tooltip.style.left = x + 'px';
-    render(<ToolTip></ToolTip>, tooltip);
+    render(<ToolTip />, tooltip);
     document.body.appendChild(tooltip);
 }
 

--- a/src/pages/Content/modules/Tooltip-Component.js
+++ b/src/pages/Content/modules/Tooltip-Component.js
@@ -25,11 +25,11 @@ export function removeTooltip() {
 const ToolTip = () => {
     return (        
         <> 
-         <button type="button" className="btn btn-success" id='smile' title="Green Highlight" onClick={()=>console.log("smile")}> <FaRegSmile id = "smile"/></button>
-          <button type="button" className="btn btn-danger" id='frown' title="Red Highlight" onClick={()=>console.log("frown")}> <FaRegFrown id ="frown"/></button>
-          <button type="button" className="btn btn-warning" id='highlight' title="Yellow Highlight" onClick={()=>console.log("highlight")}> <FaExclamation id ="highlight"/></button>
-          <button type="button" className="btn btn-primary" id='comment' title="Create comment" onClick={()=>console.log("comment")}> <FaComment id = "comment"/></button>
-          <button type="button" className="btn btn-dark" id='note' title="Personal Note" onClick={()=>console.log("note")}> <FaStickyNote id ="note"/></button>
+         <button type="button" className="btn btn-success" id='button-fix' title="Green Highlight" onClick={()=>console.log("smile")}> <FaRegSmile id = "smile"/></button>
+          <button type="button" className="btn btn-danger" id='button-fix' title="Red Highlight" onClick={()=>console.log("frown")}> <FaRegFrown id ="frown"/></button>
+          <button type="button" className="btn btn-warning" id='button-fix' title="Yellow Highlight" onClick={()=>console.log("highlight")}> <FaExclamation id ="highlight"/></button>
+          <button type="button" className="btn btn-primary" id='button-fix' title="Create comment" onClick={()=>console.log("comment")}> <FaComment id = "comment"/></button>
+          <button type="button" className="btn btn-dark" id='button-fix' title="Personal Note" onClick={()=>console.log("note")}> <FaStickyNote id ="note"/></button>
         </>
     );
     


### PR DESCRIPTION
Added id rules to keep tooltip POSITIONING consistent across supported sites


### CNN
![image](https://user-images.githubusercontent.com/29382267/114318465-140f6280-9adb-11eb-8d3e-33bea0fd9da3.png)


### Verge
![image](https://user-images.githubusercontent.com/29382267/114318485-30ab9a80-9adb-11eb-9cb0-8bd225d90463.png)


### Vox
![image](https://user-images.githubusercontent.com/29382267/114318499-3c975c80-9adb-11eb-97be-6746dfb2afba.png)


### Wired
![image](https://user-images.githubusercontent.com/29382267/114318518-52a51d00-9adb-11eb-9511-68b7e24e49fb.png)


### NYT
![image](https://user-images.githubusercontent.com/29382267/114318536-6cdefb00-9adb-11eb-86aa-df99245e0898.png)


To-DO
- [ ] Keep appearances of tooltips consistent
- [ ] Questionnaire consistency